### PR TITLE
Implemented new design for Internal/External Deps Tables

### DIFF
--- a/components/CollapsibleTable.tsx
+++ b/components/CollapsibleTable.tsx
@@ -14,12 +14,12 @@ type CollapsibleTableProps = {
 
 // Creates the whole table
 export default function CollapsibleTable(props: CollapsibleTableProps) {
-  console.log( 'PRINTING')
+  console.log('PRINTING')
   console.log(props.children)
   return (
     <TableContainer
       component={Paper}
-	  className={styles.tableComponent}
+      className={styles.tableComponent}
     >
       <Table size="small" aria-label="collapsible table">
         <colgroup>

--- a/components/CollapsibleTable.tsx
+++ b/components/CollapsibleTable.tsx
@@ -14,8 +14,6 @@ type CollapsibleTableProps = {
 
 // Creates the whole table
 export default function CollapsibleTable(props: CollapsibleTableProps) {
-  console.log('PRINTING')
-  console.log(props.children)
   return (
     <TableContainer
       component={Paper}

--- a/components/CollapsibleTable.tsx
+++ b/components/CollapsibleTable.tsx
@@ -14,6 +14,8 @@ type CollapsibleTableProps = {
 
 // Creates the whole table
 export default function CollapsibleTable(props: CollapsibleTableProps) {
+  console.log( 'PRINTING')
+  console.log(props.children)
   return (
     <TableContainer
       component={Paper}

--- a/components/HelpComponents/HelpGuide.tsx
+++ b/components/HelpComponents/HelpGuide.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Fab, Dialog, DialogTitle, DialogActions, DialogContent, DialogContentText, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
+import React from "react";
+import { Fab, Dialog, DialogTitle, DialogContent, DialogContentText, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
 import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip';
 import HelpOutline from "@mui/icons-material/HelpOutline";
 import styles from "./HelpGuide.module.css";
@@ -224,7 +224,7 @@ export default function HelpGuide() {
                 How to read the Total Repositories breakdown card?
               </DialogContentText>
               <DialogContentText className={styles.infoContentStyle}>
-                The 'Total Repos' card simply displays the number of repositories defined by each
+                The Total Repos card simply displays the number of repositories defined by each
                 light status type; red, yellow, and green.
               </DialogContentText>
               </div>

--- a/components/InternalTable.module.css
+++ b/components/InternalTable.module.css
@@ -1,0 +1,44 @@
+.tableContainer{
+	box-shadow: none;
+    background-color: var(--colour-background);
+    color: var(--colour-font);
+}
+
+.col1{
+	width: 8%;
+	background-color: var(--table-left-edge);
+}
+
+.col2 {
+	width: 10%;
+	background-color: var(--colour-background);
+}
+
+.col3 {
+	width: 50%;
+	background-color: var(--colour-background);
+}
+
+.col4 {
+	width: 25%;
+	background-color: var(--colour-background);
+}
+
+.tableCellStyle{
+	font-weight: var(--font-weight-bold);
+  	font-family: var(--primary-font-family);
+  	font-size: 1.4rem;
+	background-color: var(--table-cell-background);
+	color: var(--colour-font);
+	margin-top: 1rem;
+	line-height: 3rem;
+	border-color:  var(--table-cell-border);
+	border-width: 0.2rem;
+	color: var(--colour-text);
+}
+
+.tableStyle {
+	box-shadow: none;
+	background-color: var(--colour-background);
+	color: var(--colour-font);
+}

--- a/components/InternalTable.module.css
+++ b/components/InternalTable.module.css
@@ -1,44 +1,44 @@
-.tableContainer{
+.tableContainer {
 	box-shadow: none;
-    background-color: var(--colour-background);
-    color: var(--colour-font);
+	background-color: var(--colour-lightGrey);
+	color: var(--colour-font);
 }
 
-.col1{
-	width: 8%;
+.col1 {
+	width: 10%;
 	background-color: var(--table-left-edge);
 }
 
 .col2 {
-	width: 10%;
-	background-color: var(--colour-background);
-}
-
-.col3 {
 	width: 50%;
 	background-color: var(--colour-background);
 }
 
-.col4 {
-	width: 25%;
+.col3 {
+	width: 20%;
 	background-color: var(--colour-background);
 }
 
-.tableCellStyle{
+.col4 {
+	width: 20%;
+	background-color: var(--colour-background);
+}
+
+.tableCellStyle {
 	font-weight: var(--font-weight-bold);
-  	font-family: var(--primary-font-family);
-  	font-size: 1.4rem;
-	background-color: var(--table-cell-background);
+	font-family: var(--primary-font-family);
+	font-size: 1.4rem;
+	background-color: var(--colour-lightGrey);
 	color: var(--colour-font);
 	margin-top: 1rem;
 	line-height: 3rem;
-	border-color:  var(--table-cell-border);
+	border-color: var(--table-cell-border);
 	border-width: 0.2rem;
 	color: var(--colour-text);
 }
 
 .tableStyle {
 	box-shadow: none;
-	background-color: var(--colour-background);
+	background-color: var(--colour-lightGrey);
 	color: var(--colour-font);
 }

--- a/components/InternalTable.module.css
+++ b/components/InternalTable.module.css
@@ -25,10 +25,10 @@
 }
 
 .tableCellStyle {
-	font-weight: var(--font-weight-bold);
+	font-weight: bold;
 	font-family: var(--primary-font-family);
-	font-size: 1.4rem;
-	background-color: var(--colour-lightGrey);
+	font-size: 1.1rem;
+	background-color: #f5f5f5;
 	color: var(--colour-font);
 	margin-top: 1rem;
 	line-height: 3rem;
@@ -41,4 +41,11 @@
 	box-shadow: none;
 	background-color: var(--colour-lightGrey);
 	color: var(--colour-font);
+}
+
+.tableComponent{
+	max-height: 20.3rem;
+	overflow: scroll;
+	overflow-x: hidden;
+	box-shadow: none;
 }

--- a/components/InternalTable.tsx
+++ b/components/InternalTable.tsx
@@ -6,7 +6,7 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
-import styles from "./CollapsibleTable.module.css";
+import styles from "./InternalTable.module.css";
 
 type CollapsibleTableProps = {
     children: ReactNode;
@@ -39,3 +39,4 @@ export default function CollapsibleTable(props: CollapsibleTableProps) {
         </TableContainer>
     );
 }
+

--- a/components/InternalTable.tsx
+++ b/components/InternalTable.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from "react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import styles from "./CollapsibleTable.module.css";
+
+type CollapsibleTableProps = {
+    children: ReactNode;
+};
+
+// Creates the interior table
+export default function CollapsibleTable(props: CollapsibleTableProps) {
+    return (
+        <TableContainer
+            component={Paper}
+            className={styles.tableComponent}
+        >
+            <Table size="small" aria-label="collapsible table">
+                <colgroup>
+                    <col className={styles.col1} />
+                    <col className={styles.col2} />
+                    <col className={styles.col3} />
+                    <col className={styles.col4} />
+                </colgroup>
+                <TableHead>
+                    <TableRow>
+                        <TableCell className={styles.tableCellStyle}>status</TableCell>
+                        <TableCell className={styles.tableCellStyle}>name</TableCell>
+                        <TableCell className={styles.tableCellStyle}>current</TableCell>
+                        <TableCell className={styles.tableCellStyle}>latest</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>{props.children}</TableBody>
+            </Table>
+        </TableContainer>
+    );
+}

--- a/components/Row.module.css
+++ b/components/Row.module.css
@@ -37,7 +37,7 @@ div.iconContainer{
 .collapsibleTableCell {
 	padding-bottom: 0;
 	padding-top: 0;
-	background-color: var(--colour-lightGrey);
+	background-color: #f5f5f5;
 }
 
 .tooltipStyle {

--- a/components/Row.module.css
+++ b/components/Row.module.css
@@ -37,6 +37,7 @@ div.iconContainer{
 .collapsibleTableCell {
 	padding-bottom: 0;
 	padding-top: 0;
+	background-color: var(--colour-lightGrey);
 }
 
 .tooltipStyle {

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
 import IconButton from "@mui/material/IconButton";
-import { Tooltip, TableRow, TableHead, TableCell, Table, Typography } from "@mui/material";
+import { Tooltip, TableRow, TableHead, TableCell, Table } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import QuestionMark from "@mui/icons-material/QuestionMark";

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -5,7 +5,6 @@ import IconButton from "@mui/material/IconButton";
 import { Tooltip, TableRow, TableHead, TableCell, Table } from "@mui/material";
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import QuestionMark from "@mui/icons-material/QuestionMark";
 import RedIcon from "./images/redIcon.svg";
 import YellowIcon from "./images/yellowIcon.svg";
@@ -50,23 +49,23 @@ export default function Row(props: { rank: number; row: any } & Props) {
             aria-label="expand row"
             size="small"
             onClick={() => setOpen(!open)}
-			      className={styles.rowArrow}
+            className={styles.rowArrow}
           >
             {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
           </IconButton>
         </TableCell>
         <TableCell className={styles.tableCellStyle}>
-        <Tooltip arrow title={<p className={styles.tooltipStyle}>{ iconDefinition }</p>}>
-          <div className={styles.iconContainer}>
-            <Image
+          <Tooltip arrow title={<p className={styles.tooltipStyle}>{iconDefinition}</p>}>
+            <div className={styles.iconContainer}>
+              <Image
                 src={statusIcon}
                 alt="Repo Priority"
                 width="40px"
                 height="40px"
                 className={styles.statusIcon}
-            />
-          </div>
-        </Tooltip>
+              />
+            </div>
+          </Tooltip>
         </TableCell>
         <TableCell className={styles.tableCellStyle} component="th" scope="row">
           {row.name}
@@ -76,7 +75,7 @@ export default function Row(props: { rank: number; row: any } & Props) {
           {
             (semVerToString(row.version) === "0.0.0-development" || semVerToString(row.version) === "0.0.0") &&
             <Tooltip arrow title={<p className={styles.tooltipStyle}>This repository was defined with a default version of 0.0.0</p>}>
-              <QuestionMark className={styles.questionIcon}/>
+              <QuestionMark className={styles.questionIcon} />
             </Tooltip>
           }
         </TableCell>
@@ -94,7 +93,7 @@ export default function Row(props: { rank: number; row: any } & Props) {
           colSpan={6}
         >
           <Collapse in={open} timeout="auto" unmountOnExit>
-            <Box sx={{ margin: 1}}>
+            <Box sx={{ margin: 1 }}>
               <Table size="small" aria-label="dependencies">
                 <TableHead className={styles.collapsibleTableHead} >
                   <TableRow>

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -3,6 +3,7 @@ import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
 import IconButton from "@mui/material/IconButton";
 import { Tooltip, TableRow, TableHead, TableCell, Table } from "@mui/material";
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import QuestionMark from "@mui/icons-material/QuestionMark";
@@ -51,7 +52,7 @@ export default function Row(props: { rank: number; row: any } & Props) {
             onClick={() => setOpen(!open)}
 			      className={styles.rowArrow}
           >
-            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+            {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
           </IconButton>
         </TableCell>
         <TableCell className={styles.tableCellStyle}>

--- a/components/SubRow.module.css
+++ b/components/SubRow.module.css
@@ -1,8 +1,9 @@
 .tableCellStyle{
     font-family: var(--secondary-font-family);
-    font-size: var(--font-size-large);
-	background-color: var(--colour-lightGrey);
-	color: var(--colour-font)
+    font-size: 1.1rem;
+	background-color: #f5f5f5;
+	color: var(--colour-font);
+	border-color: #7a7a7a;
 }
 
 .latestVerStyle{

--- a/components/SubRow.module.css
+++ b/components/SubRow.module.css
@@ -1,7 +1,7 @@
 .tableCellStyle{
     font-family: var(--secondary-font-family);
     font-size: var(--font-size-large);
-	background-color: var(--colour-container-background);
+	background-color: var(--colour-lightGrey);
 	color: var(--colour-font)
 }
 
@@ -10,7 +10,7 @@
 }
 
 .inverseSubRow {
-	background-color: var(--colour-background);
+	background-color: var(--colour-lightGrey);
 	color: var(--colour-font);
 }
 

--- a/components/SummaryContainer.tsx
+++ b/components/SummaryContainer.tsx
@@ -83,3 +83,4 @@ export default function SummaryContainer(props: {
     </div>
   );
 }
+

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -4,6 +4,7 @@ import Tab from "@mui/material/Tab";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import Badge from "@mui/material/Badge";
+import InternalTable from "./InternalTable";
 
 import { makeStyles } from "@mui/styles";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
@@ -22,7 +23,7 @@ const useStyles = makeStyles((_) => ({
     height: "0.625rem", //"10px"
     top: "2.813rem", //"45px"
     color: "black",
-    marginTop:  "0.625rem",
+    marginTop: "0.625rem",
   },
 }));
 
@@ -158,13 +159,13 @@ const Tabs = (props: Props) => {
 
   let tabPanels = [
     <TabPanel key="internal" value={tabVal} index={0}>
-      {internal.length > 0 ? internal : "No internal depedencies found"}
+      <InternalTable>{internal}</InternalTable>
     </TabPanel>,
     <TabPanel key="external" value={tabVal} index={1}>
-      {external.length > 0 ? external : "No external depedencies found"}
+      <InternalTable>{external}</InternalTable>
     </TabPanel>,
     <TabPanel key="users" value={tabVal} index={2}>
-      {user.length > 0 ? user : "No dependent repositories found"}
+      <InternalTable>{user}</InternalTable>
     </TabPanel>,
   ];
 

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import Badge from "@mui/material/Badge";
 import InternalTable from "./InternalTable";
+import UsersTable from './UsersTable'
 
 import { makeStyles } from "@mui/styles";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
@@ -124,7 +125,7 @@ const Tabs = (props: Props) => {
 
   const internalTable = <InternalTable>{internal}</InternalTable>;
   const externalTable = <InternalTable>{external}</InternalTable>;
-  const userTable = <InternalTable>{user}</InternalTable>;
+  const userTable = <UsersTable>{user}</UsersTable>;
 
   const [tabVal, setTabVal] = useState(0);
   const classes = useStyles();

--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -40,6 +40,7 @@ const theme = createTheme({
         root: {
           textTransform: "none",
           fontWeight: "bold",
+          fontSize: '500',
           fontFamily: "Work Sans, sans-serif",
           width: "30%",
           maxWidth: "18.75rem", //"300px"
@@ -47,7 +48,7 @@ const theme = createTheme({
           flexDirection: "row",
         },
         textColorSecondary: {
-          color: "#eeeee4",
+          color: "#9e9b99",
           textTransform: "none",
           fontWeight: "normal",
         },
@@ -121,6 +122,10 @@ const Tabs = (props: Props) => {
   const external = props.subRows.external;
   const user = props.subRows.user;
 
+  const internalTable = <InternalTable>{internal}</InternalTable>;
+  const externalTable = <InternalTable>{external}</InternalTable>;
+  const userTable = <InternalTable>{user}</InternalTable>;
+
   const [tabVal, setTabVal] = useState(0);
   const classes = useStyles();
   const handleChange = (event: SyntheticEvent, newValue: number) => {
@@ -159,13 +164,13 @@ const Tabs = (props: Props) => {
 
   let tabPanels = [
     <TabPanel key="internal" value={tabVal} index={0}>
-      <InternalTable>{internal}</InternalTable>
+      {internal.length > 0 ? internalTable : "No depedencies found"}
     </TabPanel>,
     <TabPanel key="external" value={tabVal} index={1}>
-      <InternalTable>{external}</InternalTable>
+      {external.length > 0 ? externalTable : "No depedencies found"}
     </TabPanel>,
     <TabPanel key="users" value={tabVal} index={2}>
-      <InternalTable>{user}</InternalTable>
+      {user.length > 0 ? userTable : "No dependent repositories found"}
     </TabPanel>,
   ];
 

--- a/components/UsersTable.module.css
+++ b/components/UsersTable.module.css
@@ -1,39 +1,29 @@
 .tableContainer {
 	box-shadow: none;
-	background-color: var(--colour-background);
+	background-color: var(--colour-lightGrey);
 	color: var(--colour-font);
 }
 
 .col1 {
-	width: 0%;
+	width: 20%;
 	background-color: var(--table-left-edge);
 }
 
 .col2 {
-	width: 6%;
+	width: 50%;
 	background-color: var(--colour-background);
 }
 
 .col3 {
-	width: 75%;
-	background-color: var(--colour-background);
-}
-
-.col4 {
-	width: 25%;
-	background-color: var(--colour-background);
-}
-
-.col5 {
-	width: 0%;
+	width: 30%;
 	background-color: var(--colour-background);
 }
 
 .tableCellStyle {
-	font-weight: var(--font-weight-bold);
+	font-weight: bold;
 	font-family: var(--primary-font-family);
-	font-size: 1.4rem;
-	background-color: var(--table-cell-background);
+	font-size: 1.1rem;
+	background-color: #f5f5f5;
 	color: var(--colour-font);
 	margin-top: 1rem;
 	line-height: 3rem;
@@ -44,10 +34,13 @@
 
 .tableStyle {
 	box-shadow: none;
-	background-color: var(--colour-background);
+	background-color: var(--colour-lightGrey);
 	color: var(--colour-font);
 }
 
 .tableComponent{
+	max-height: 20.3rem;
+	overflow: scroll;
+	overflow-x: hidden;
 	box-shadow: none;
 }

--- a/components/UsersTable.tsx
+++ b/components/UsersTable.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from "react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import styles from "./InternalTable.module.css";
+
+type CollapsibleTableProps = {
+    children: ReactNode;
+};
+
+// Creates the interior table
+export default function CollapsibleTable(props: CollapsibleTableProps) {
+    return (
+        <TableContainer
+            component={Paper}
+            className={styles.tableComponent}
+        >
+            <Table size="small" aria-label="collapsible table">
+                <colgroup>
+                    <col className={styles.col1} />
+                    <col className={styles.col2} />
+                    <col className={styles.col3} />
+                </colgroup>
+                <TableHead>
+                    <TableRow>
+                        <TableCell className={styles.tableCellStyle}>status</TableCell>
+                        <TableCell className={styles.tableCellStyle}>name</TableCell>
+                        <TableCell className={styles.tableCellStyle}>current</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>{props.children}</TableBody>
+            </Table>
+        </TableContainer>
+    );
+}
+


### PR DESCRIPTION
**New Design for internal tables**
1. Added Headers for internal, external & users tables
2. Grey background color to differentiate between dependencies & repositories tables
3. Added Scrollbar for dependencies tables
4. Changed the expand icon to the right arrow instead of the down arrow

Updated Design
![New Internal Tables](https://user-images.githubusercontent.com/81655881/188255066-b1c5f18c-13d7-493e-a3b2-88a2325c1b09.PNG)

Old Design
![Old Table](https://user-images.githubusercontent.com/81655881/188255086-e8234a94-c292-4cda-a831-5000e5011163.PNG)
