### PR TITLE
Fixing text overflow and sign in card/buttons CSS bugs

### DIFF
--- a/global.css
+++ b/global.css
@@ -75,6 +75,10 @@ a:active {
 	--rank-green: rgba(31, 162, 25, 1);
 	--rank-orange: rgb(235, 158, 17);
 	--rank-red: rgb(230, 62, 24);
+
+	/* Colours for Sign-in page login & success icons */
+	--login-success: rgba(31, 162, 25, 1);
+	--login-failed: rgb(230, 62, 24);
 	
 	--rank-light-green: #cfc;
 	--rank-green-border: 1px solid green;

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,288 +1,333 @@
 import { useState, useEffect } from "react";
-import { useRouter } from "next/router"
-import { Button, CircularProgress, Grid, Paper, Typography, Box } from "@mui/material";
+import { useRouter } from "next/router";
+import {
+  Button,
+  CircularProgress,
+  Grid,
+  Paper,
+  Typography,
+  Box,
+} from "@mui/material";
 import styles from "../styles/signin.module.css";
 import { GitHubIcon } from "../components/GitHubIcon";
-import * as React from 'react';
-import TrafficIcon from '@mui/icons-material/Traffic';
+import * as React from "react";
+import TrafficIcon from "@mui/icons-material/Traffic";
 import Image from "next/image";
 import ForestIcon from "@mui/icons-material/Forest";
-import greenIcon from "../components/images/greenIcon.svg";
-import redIcon from '../components/images/redIcon.svg'
+import GreenSuccessIcon from "../components/images/greenLight.svg";
+import RedFailIcon from "../components/images/redLight.svg";
 
-const SCOPE = "repo"
-
+const SCOPE = "repo";
 
 export async function getServerSideProps() {
-	return {
-	props: {
-		clientID : process.env.NEXT_PUBLIC_CLIENT_ID,
-		redirectURI : process.env.NEXT_PUBLIC_REDIRECT_URI,
-	  }, // will be passed to the page component as props
-	}
-  }
+  return {
+    props: {
+      clientID: process.env.NEXT_PUBLIC_CLIENT_ID,
+      redirectURI: process.env.NEXT_PUBLIC_REDIRECT_URI,
+    }, // will be passed to the page component as props
+  };
+}
 
 // get code
 function redirect(clientID: string, redirectURI: string) {
-	const uuid = self.crypto.randomUUID();
-	window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientID}&redirect_uri=${redirectURI}&scope=${SCOPE}&state=${uuid}`;
+  const uuid = self.crypto.randomUUID();
+  window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientID}&redirect_uri=${redirectURI}&scope=${SCOPE}&state=${uuid}`;
 }
 
-type SignInStatus = "calculating" | "not-signed-in" | "exchanging-code-for-token" | "signed-in" | "error-while-signing-in"
+type SignInStatus =
+  | "calculating"
+  | "not-signed-in"
+  | "exchanging-code-for-token"
+  | "signed-in"
+  | "error-while-signing-in";
 
+export default function SignIn(props: {
+  clientID: string;
+  redirectURI: string;
+}) {
+  const router = useRouter();
 
-export default function SignIn(props: {clientID: string, redirectURI: string} ) {
+  const [token, setToken] = useState<string>("");
 
-	const router = useRouter()
+  const [signInStatus, setSignInStatus] = useState<SignInStatus>("calculating");
 
-	const [token, setToken] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>();
 
-	const [signInStatus, setSignInStatus] = useState<SignInStatus>("calculating")
+  useEffect(() => {
+    setErrorMessage(undefined as any);
 
-	const [errorMessage, setErrorMessage] = useState<string>()
+    if (router == null) {
+      return;
+    }
+    const code = router.query.code?.toString();
+    const error = router.query.error?.toString();
 
-	useEffect(() => {
-		setErrorMessage(undefined as any)
+    if (error != null) {
+      setSignInStatus("error-while-signing-in");
+      error === "access_denied" &&
+        setErrorMessage(
+          "You have denied access to your GitHub account. Please try again."
+        );
+      error === "not_a_member" &&
+        setErrorMessage(
+          "You are not a member of the organisation. Please sign in with a different account."
+        );
+    } else if (code != null) {
+      setSignInStatus("exchanging-code-for-token");
+      console.log(`code ${code}`);
 
-		if (router == null) {
-			return
-		}
-		const code = router.query.code?.toString()
-		const error = router.query.error?.toString()
+      //This immediately called function must be defined because useEffect handlers cannot be async
+      const isSignedIn = async () => {
+        const response = await fetch(
+          `/api/authenticate/${encodeURIComponent(code.toString())}/`
+        );
+        if (response.status == 200) {
+          return true;
+        }
 
-		if (error != null) {
-			setSignInStatus('error-while-signing-in')
-			error === "access_denied" && setErrorMessage("You have denied access to your GitHub account. Please try again.")
-			error === "not_a_member" && setErrorMessage("You are not a member of the organisation. Please sign in with a different account.")
-		} else if (code != null) {
-			setSignInStatus('exchanging-code-for-token')
-			console.log(`code ${code}`);
+        throw await response.json();
+      };
+      isSignedIn()
+        .then(async () => {
+          setSignInStatus("signed-in");
+        })
+        .catch((error) => {
+          console.log("error while exchanging token", error);
+          setSignInStatus("error-while-signing-in");
+          error?.message && setErrorMessage(error.message);
+        });
+    } else {
+      setSignInStatus("not-signed-in");
+    }
+  }, [router]);
 
-			//This immediately called function must be defined because useEffect handlers cannot be async
-			const isSignedIn = async () => {
-				const response = await fetch(`/api/authenticate/${encodeURIComponent(code.toString())}/`);
-				if (response.status == 200) {
-					return true
-				}
+  /**
+   * Called when the user clicks the Try Again button after an error occurred
+   */
+  function handleTryAgain() {
+    router.push("/signin");
+  }
 
-				throw await response.json()
-			};
-			isSignedIn()
-				.then(async () => {
-					setSignInStatus('signed-in')
-				})
-				.catch((error) => {
+  return (
+    <>
+      <Grid
+        container
+        alignItems="stretch"
+        sx={{
+          height: "100vh",
+        }}
+      >
+        <Grid
+          item
+          xs={12}
+          md={5}
+          sx={{
+            backgroundImage:
+              "linear-gradient(115deg, #CFF4D2, #7BE495, #56C596, #329D9C, #205072)",
+            backgroundSize: "cover",
+            backgroundPositionX: "80%",
+            position: "relative",
+            overflow: "hidden",
+          }}
+        >
+          <Box sx={{ padding: 4 }}>
+            <Typography sx={{ fontWeight: "bold" }} variant="h4">
+              Evergreen <ForestIcon />{" "}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: "var(--font-size-large)",
+                fontWeight: "var(--font-weight-normal)",
+              }}
+              variant="body1"
+            >
+              Evergreen lets you track all your dependencies in one simple
+              dashboard.
+            </Typography>
+          </Box>
 
-					console.log("error while exchanging token", error)
-					setSignInStatus('error-while-signing-in')
-					error?.message && setErrorMessage(error.message)
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: "0",
+              left: "75px",
+              width: "120%",
+              display: {
+                xs: "none",
+                md: "initial",
+              },
+            }}
+          >
+            <Image
+              src="/dashboardSS.png"
+              alt="Screenshot of the Evergreen Dashboard"
+              width={2692}
+              height={2048}
+            />
+          </Box>
+        </Grid>
+      </Grid>
 
-				});
+      <Grid
+        sx={{
+          position: "fixed",
+          top: "50%",
+          left: {
+            xs: "50%",
+            md: "70.83%", // 5/12 + (1 - 5/12) * 1/2
+          },
+          transform: "translate(-50%, -50%)",
 
-		} else {
-			setSignInStatus('not-signed-in')
-		}
+          width: {
+            xs: "100%",
+            md: "58.33%", // 1 - 5/12
+          },
+          padding: 4,
+        }}
+        container
+        className={styles.signinPage}
+        justifyContent="center"
+        alignContent="center"
+      >
+        <Paper className={styles.signinContainer}>
+          <Typography
+            variant="h4"
+            sx={{ marginBottom: "1.5rem", marginLeft: "1rem" }}
+            component="h1"
+          >
+            <span className={styles.everGreen}>Evergreen Dashboard</span>{" "}
+          </Typography>
 
-	}, [router]);
+          {signInStatus === "calculating" && (
+            <>
+              <Grid container direction="column" alignItems="center">
+                <CircularProgress />
+              </Grid>
+            </>
+          )}
+          {signInStatus === "not-signed-in" && (
+            <>
+              <Box
+                sx={{
+                  paddingBottom: 3,
+                  paddingTop: 5,
+                }}
+              >
+                <Button
+                  variant="contained"
+                  size="large"
+                  className={styles.signinWithGithubButton}
+                  onClick={() => redirect(props.clientID, props.redirectURI)}
+                  startIcon={<GitHubIcon />}
+                >
+                  Sign In With GitHub
+                </Button>
+              </Box>
+            </>
+          )}
+          {signInStatus === "exchanging-code-for-token" && (
+            <>
+              <Grid container direction="column" alignItems="center">
+                <CircularProgress />
+              </Grid>
+            </>
+          )}
+          {signInStatus === "error-while-signing-in" && (
+            <>
+              <Grid container direction="column" alignItems="center">
+                <Typography
+                  align="center"
+                  variant="h5"
+                  sx={{
+                    marginBottom: "1.5rem",
+                    fontWeight: "bold",
+                    color: "var(--colour-red)",
+                  }}
+                >
+                  Error!
+                </Typography>
 
-	/**
-	 * Called when the user clicks the Try Again button after an error occurred
-	 */
-	function handleTryAgain() {
-		router.push("/signin")
-	}
+                <RedFailIcon
+                  layout="fixed"
+                  alt={"Login Failed"}
+                  width="40px"
+                  height={"40px"}
+                  fill={"var(--login-failed)"}
+                />
 
-	return (
-		<>
-			<Grid container alignItems="stretch" sx={{
-				height: '100vh'
-			}}>
-				<Grid item xs={12} md={5} sx={{
-					backgroundImage: 'linear-gradient(115deg, #CFF4D2, #7BE495, #56C596, #329D9C, #205072)',
-					backgroundSize: 'cover',
-					backgroundPositionX: '80%',
-					position: 'relative',
-					overflow: 'hidden',
-				}}>
+                <Typography
+                  variant="body1"
+                  sx={{
+                    color: "var(--colour--black)",
+                    marginTop: "1rem",
+                    marginBottom: "1rem",
+                  }}
+                >
+                  {errorMessage
+                    ? errorMessage
+                    : "Whoops! There was an error while trying to sign you in."}
+                </Typography>
+                <Button
+                  onClick={handleTryAgain}
+                  variant="contained"
+                  color="error"
+                >
+                  Try Again
+                </Button>
+              </Grid>
+            </>
+          )}
+          {signInStatus === "signed-in" && (
+            <>
+              <Grid container direction="column" alignItems="center">
+                <Typography
+                  align="center"
+                  variant="h5"
+                  sx={{
+                    marginBottom: "1.5rem",
+                    fontWeight: "bold",
+                    color: "var(--colour-green)",
+                  }}
+                >
+                  Success!
+                </Typography>
 
-					<Box sx={{ padding: 4 }}>
-						<Typography sx={{ fontWeight: 'bold' }} variant="h4">Evergreen <ForestIcon /> </Typography>
-						<Typography sx={{ fontSize: 'var(--font-size-large)', fontWeight: 'var(--font-weight-normal)' }} variant="body1">
-							Evergreen lets you track all your dependencies in one simple dashboard.
-						</Typography>
-					</Box>
+                <GreenSuccessIcon
+                  layout="fixed"
+                  alt={"Login Sucessfull"}
+                  width="40px"
+                  height={"40px"}
+                  fill={"var(--login-success)"}
+                />
 
-					<Box sx={{
-						position: 'absolute',
-						bottom: '0',
-						left: '75px',
-						width: '120%',
-						display: {
-							xs: 'none',
-							md: 'initial'
-						}
-					}}>
+                <Typography
+                  align="center"
+                  variant="body1"
+                  sx={{
+                    color: "var(--colour--black)",
+                    marginTop: "1rem",
+                    marginBottom: "1rem",
+                  }}
+                >
+                  Your login was successful
+                </Typography>
 
-						<Image
-							src='/dashboardSS.png'
-							alt="Screenshot of the Evergreen Dashboard"
-							width={2692}
-							height={2048} />
-					</Box>
-
-				</Grid>
-			</Grid>
-
-			<Grid
-				sx={{
-					position: 'fixed',
-					top: '50%',
-					left: {
-						xs: '50%',
-						md: '70.83%' // 5/12 + (1 - 5/12) * 1/2
-					},
-					transform: 'translate(-50%, -50%)',
-
-					width: {
-						xs: '100%',
-						md: '58.33%' // 1 - 5/12
-					},
-					padding: 4
-				}}
-				container
-				className={styles.signinPage}
-				justifyContent='center'
-				alignContent='center'>
-				<Paper className={styles.signinContainer}>
-					<Typography variant="h4" sx={{ marginBottom: '1.5rem', marginLeft: '1rem'}} component="h1"><span className={styles.everGreen}>Evergreen Dashboard</span> </Typography>
-
-					{
-						signInStatus === "calculating" && <>
-							<Grid
-								container
-								direction='column'
-								alignItems='center'
-							>
-								<CircularProgress />
-							</Grid>
-						</>
-					}
-					{
-						signInStatus === "not-signed-in" && <>
-
-							<Box sx={{
-								paddingBottom: 3,
-								paddingTop: 5
-							}}>
-								<Button
-									variant="contained"
-									size="large"
-									className={styles.signinWithGithubButton}
-									onClick={() => redirect(props.clientID, props.redirectURI)}
-									startIcon={<GitHubIcon />}
-								>Sign In With GitHub</Button>
-							</Box>
-						</>
-					}
-					{
-						signInStatus === "exchanging-code-for-token" && <>
-							<Grid
-								container
-								direction='column'
-								alignItems='center'
-							>
-								<CircularProgress />
-							</Grid>
-						</>
-					}
-					{
-						signInStatus === "error-while-signing-in" && <>
-
-							<Grid
-								container
-								direction='column'
-								alignItems='center'
-							>
-
-								<Typography
-									align='center'
-									variant="h5"
-									sx={{
-										marginBottom: '1.5rem',
-										fontWeight: 'bold',
-										color: 'var(--colour-red)'
-									}}>
-									Error!
-								</Typography>
-
-								<Image src={redIcon} alt="Login Failed" width="40px"
-									height="40px" />
-
-								<Typography
-									variant="body1"
-									sx={{
-										color: 'var(--colour--black)',
-										marginTop: '1rem',
-										marginBottom: '1rem'
-
-									}}>
-									{
-										errorMessage
-											? errorMessage
-											: "Whoops! There was an error while trying to sign you in."
-									}
-								</Typography>
-								<Button onClick={handleTryAgain} variant='contained' color='error'>Try Again</Button>
-							</Grid>
-
-						</>
-					}
-					{
-						signInStatus === "signed-in" && <>
-							<Grid
-								container
-								direction='column'
-								alignItems='center'
-							>
-
-								<Typography
-									align='center'
-									variant="h5"
-									sx={{
-										marginBottom: '1.5rem',
-										fontWeight: 'bold',
-										color: 'var(--colour-green)'
-									}}>
-									Success!
-								</Typography>
-
-								<Image src={greenIcon} alt="Login Success" width="40px"
-									height="40px" />
-
-								<Typography
-									align='center'
-									variant="body1"
-									sx={{
-										color: 'var(--colour--black)',
-										marginTop: '1rem',
-										marginBottom: '1rem'
-									}}>
-									Your login was successful
-								</Typography>
-
-								<Button variant="contained"
-									size="large"
-									endIcon={<TrafficIcon />}
-									sx={{
-										backgroundColor: 'var(--colour-green)'
-									}}
-									href="/">Continue to Dashboard</Button>
-							</Grid>
-						</>
-					}
-				</Paper>
-
-			</Grid>
-		</>
-	);
+                <Button
+                  variant="contained"
+                  size="large"
+                  endIcon={<TrafficIcon />}
+                  sx={{
+                    backgroundColor: "var(--colour-green)",
+                  }}
+                  href="/"
+                >
+                  Continue to Dashboard
+                </Button>
+              </Grid>
+            </>
+          )}
+        </Paper>
+      </Grid>
+    </>
+  );
 }

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -19,6 +19,38 @@ import RedFailIcon from "../components/images/redLight.svg";
 
 const SCOPE = "repo";
 
+// Sign In with GitHub button
+const signInButtonStyling = {
+  backgroundColor: "black",
+  width: "100%",
+  "&:hover": {
+    backgroundColor: "#2e2e2e",
+  },
+};
+
+// Sign in box styling
+const signInContainer = {
+  width: "100%",
+  maxWidth: "400px",
+  minHeight: "200px",
+  padding: "1.5rem",
+  backgroundColor: "var(--colour-white)",
+  boxShadow: "var(--main-section-boxshadow)",
+  borderRadius: "var(--main-section-border-radius)",
+  fontFamily: "var(--primary-font-family)",
+  boxSizing: "content-box",
+  justifyContent: "center",
+};
+
+// Continue to dashboard button
+const continueToButton = {
+  backgroundColor: "var(--colour-green)",
+  width: "100%",
+  "&:hover": {
+    backgroundColor: "rgb(45, 210, 36);",
+  },
+};
+
 export async function getServerSideProps() {
   return {
     props: {
@@ -189,7 +221,7 @@ export default function SignIn(props: {
         justifyContent="center"
         alignContent="center"
       >
-        <Paper className={styles.signinContainer}>
+        <Paper sx={signInContainer}>
           <Typography
             variant="h4"
             sx={{ marginBottom: "1.5rem", marginLeft: "1rem" }}
@@ -216,7 +248,7 @@ export default function SignIn(props: {
                 <Button
                   variant="contained"
                   size="large"
-                  className={styles.signinWithGithubButton}
+                  sx={signInButtonStyling}
                   onClick={() => redirect(props.clientID, props.redirectURI)}
                   startIcon={<GitHubIcon />}
                 >
@@ -316,9 +348,7 @@ export default function SignIn(props: {
                   variant="contained"
                   size="large"
                   endIcon={<TrafficIcon />}
-                  sx={{
-                    backgroundColor: "var(--colour-green)",
-                  }}
+                  sx={continueToButton}
                   href="/"
                 >
                   Continue to Dashboard

--- a/styles/SummaryContainer.module.css
+++ b/styles/SummaryContainer.module.css
@@ -355,10 +355,6 @@ h1.noMargins {
     margin-bottom: 0.5rem !important;
   }
 
-  h3.overallCentredTitleStyle {
-    font-size: 1.75rem;
-  }
-
   h3.summaryStylePercent {
     font-size: 1.75rem;
   }

--- a/styles/signin.module.css
+++ b/styles/signin.module.css
@@ -8,19 +8,6 @@
 	height: 100vh;
 }
 
-.signinContainer {
-	width: 100%;
-	max-width: 400px;
-	min-height: 200px;
-	padding: 1.5rem;
-	background-color: var(--colour-white);
-	box-shadow: var(--main-section-boxshadow);
-	border-radius: var(--main-section-border-radius);
-	font-family: var(--primary-font-family);
-	box-sizing: content-box;
-	justify-content: center;
-}
-
 .signinWithGithubButton {
 	background-color: black;
 	width: 100%;


### PR DESCRIPTION
## What's New
**Issues Fixed**
- Fixed https://github.com/ahm-monash/evergreen/issues/271
- Fixed https://github.com/ahm-monash/evergreen/issues/283

**Changes Made**
- Fixed overall card text 'x/x repositories up-to-date' overflow bug
- Fixed login success/error icons not being displayed on the sign-in page
- Updated styling for sign-in container card button colors for production build

## Screenshots of changes made
**Text Overflow - On Large Screens (over 1600px) (Now & Before)**
![After](https://user-images.githubusercontent.com/81655881/199685125-b956e05f-8666-44d8-9dd1-35e59b535680.png)
![Before](https://user-images.githubusercontent.com/81655881/199685144-b17e271f-6de6-4d28-939a-15522442f79b.png)

**Success Icon not loading - Bug Fixed (Now & Before)**
![New Rounded Box](https://user-images.githubusercontent.com/81655881/199685426-07962aaf-08d7-404d-ae19-436f52cfd865.png)
![Before](https://user-images.githubusercontent.com/81655881/199685399-c3f07f59-c712-495a-8133-f0fce175bee0.png)

**Sign-in Buttons colors fixed on production build - Bug Fixed (Now & Before)**
Now
![Blue Sign In Black Button](https://user-images.githubusercontent.com/81655881/199685697-7cc816d3-8e71-4c03-9989-dd3ff3796b12.png)
![On Hover Continue NEW](https://user-images.githubusercontent.com/81655881/199685713-0ee41540-cf30-43cd-b3df-8bf256d5fadf.png)

Before
![Blue Sign In Button Colour Bug](https://user-images.githubusercontent.com/81655881/199685591-201a9afb-6688-4f32-8066-d1491d126bc4.png)
![On Hover Continue OLD](https://user-images.githubusercontent.com/81655881/199685638-dc10b8df-7014-4e4c-b1e5-65fb8fc96e5d.png)


