### PR TITLE
Add chips for selected dependency filter

### DIFF
--- a/components/Page.tsx
+++ b/components/Page.tsx
@@ -77,6 +77,8 @@ const theme2 = createTheme({
   },
 });
 
+export let topOfRepoBox = {data: React.createRef()}
+
 export function Page(props: PageProps) {
   // Using react state for table data
   const rows = useProcessDependencyData(props.JSObject);
@@ -311,6 +313,7 @@ export function Page(props: PageProps) {
             rankSelection={rankSelectionList}
             emptyRows={emptyRows}
             filterSetting={filterSetting}
+            setFilterSetting={setFilterSetting}
             targetOrganisation={props.targetOrganisation}
             finalisedData={finalisedData}
           />

--- a/components/ReposTableComponents/DependenciesContainer.tsx
+++ b/components/ReposTableComponents/DependenciesContainer.tsx
@@ -6,143 +6,169 @@ import { DependencyData, ID } from "../../src/dataProcessing";
 import { Filter } from "../../src/sortingAndFiltering";
 import { ProcessedDependencyData } from "../../hooks/useProcessDependencyData";
 import { GridTable } from "../MobileComponents/GridTable";
-import FilterListIcon from '@mui/icons-material/FilterList';
+import FilterListIcon from "@mui/icons-material/FilterList";
 import { Box, Chip, Grid, IconButton } from "@mui/material";
 import {
-	PageLoaderCurrentData,
-	forceNewVersion,
-	PageLoaderIsLoading,
-	lastRequest,
-	PageLoaderSetData,
-	PageLoaderSetLoading,
+  PageLoaderCurrentData,
+  forceNewVersion,
+  PageLoaderIsLoading,
+  lastRequest,
+  PageLoaderSetData,
+  PageLoaderSetLoading,
 } from "../PageLoader";
 
-import {topOfRepoBox} from "../Page"
+import { topOfRepoBox } from "../Page";
 
 let refreshing = false;
 
 /* Container includes  Search, Filter, Dependencies Table */
 export default function DependenciesContainer(props: {
-	JSObject: DependencyData;
-	tableRows: ProcessedDependencyData;
-	setTableRows: React.Dispatch<React.SetStateAction<ProcessedDependencyData>>	;
-	searchTerm: string;
-	setSearchTerm: React.Dispatch<React.SetStateAction<string>>;
-	sortDropdown: JSX.Element;
-	rankSelection: JSX.Element;
-	emptyRows: boolean;
-	sortDirection: JSX.Element;
-	filterSetting: Filter;
-	setFilterSetting: React.Dispatch<React.SetStateAction<Filter>>;
-	targetOrganisation: string;
-	finalisedData: ProcessedDependencyData;
+  JSObject: DependencyData;
+  tableRows: ProcessedDependencyData;
+  setTableRows: React.Dispatch<React.SetStateAction<ProcessedDependencyData>>;
+  searchTerm: string;
+  setSearchTerm: React.Dispatch<React.SetStateAction<string>>;
+  sortDropdown: JSX.Element;
+  rankSelection: JSX.Element;
+  emptyRows: boolean;
+  sortDirection: JSX.Element;
+  filterSetting: Filter;
+  setFilterSetting: React.Dispatch<React.SetStateAction<Filter>>;
+  targetOrganisation: string;
+  finalisedData: ProcessedDependencyData;
 }) {
-	async function callRefresh() {
-		if (refreshing) {
-			return;
-		}
-		if (lastRequest == null) {
-			return;
-		}
-		if (PageLoaderIsLoading) {
-			return;
-		}
-		PageLoaderSetLoading(true);
-		PageLoaderSetData({
-			refreshing: true,
-			data: PageLoaderCurrentData as any,
-		} as any);
+  async function callRefresh() {
+    if (refreshing) {
+      return;
+    }
+    if (lastRequest == null) {
+      return;
+    }
+    if (PageLoaderIsLoading) {
+      return;
+    }
+    PageLoaderSetLoading(true);
+    PageLoaderSetData({
+      refreshing: true,
+      data: PageLoaderCurrentData as any,
+    } as any);
 
-		refreshing = true;
+    refreshing = true;
 
-		//TODO: Support other configuration
-		//switch(mode){
-		//	case(Mode.Frontend): break;
-		//	case(Mode.StandaloneBackend):break;
-		//	case(Mode.IntegratedBackend): {
-		forceNewVersion(lastRequest).then(async (result) => {
-			PageLoaderSetData(result as any);
-			PageLoaderSetLoading(false);
-			refreshing = false;
-		});
-		//	} break;
-		//
-	}
+    //TODO: Support other configuration
+    //switch(mode){
+    //	case(Mode.Frontend): break;
+    //	case(Mode.StandaloneBackend):break;
+    //	case(Mode.IntegratedBackend): {
+    forceNewVersion(lastRequest).then(async (result) => {
+      PageLoaderSetData(result as any);
+      PageLoaderSetLoading(false);
+      refreshing = false;
+    });
+    //	} break;
+    //
+  }
 
-	const [filterOpen, setFilterOpen] = React.useState(false);
+  const [filterOpen, setFilterOpen] = React.useState(false);
 
-	const toggleFilter = () => {
-		setFilterOpen(!filterOpen);
-	};
+  const toggleFilter = () => {
+    setFilterOpen(!filterOpen);
+  };
 
-	const deleteChip = () => {
-		props.setFilterSetting({...props.filterSetting, mustHaveDependency: -1})
-	};
+  const deleteChip = () => {
+    props.setFilterSetting({ ...props.filterSetting, mustHaveDependency: -1 });
+  };
 
-	const filterSelectGridDisplay = {
-		display: {
-			xs: filterOpen ? "block" : "none",
-			md: 'initial'
-		}
-	};
+  const filterSelectGridDisplay = {
+    display: {
+      xs: filterOpen ? "block" : "none",
+      md: "initial",
+    },
+  };
 
-	return (
-		<Box ref={topOfRepoBox.data} className={styles.sectionContainer} sx={{
-			padding: {
-				xs: 2,
-				md: '2.5rem 3.125rem 3.75rem 3.125rem',
-			}
-		}}>
-			<h2 className={sharedStyles.h2ContainerStyle}>Repositories </h2>
+  return (
+    <Box
+      ref={topOfRepoBox.data}
+      className={styles.sectionContainer}
+      sx={{
+        padding: {
+          xs: 2,
+          md: "2.5rem 3.125rem 3.75rem 3.125rem",
+        },
+      }}
+    >
+      <h2 className={sharedStyles.h2ContainerStyle}>Repositories </h2>
 
-			<Grid container spacing={2}>
-				<Grid item xs={12} lg={5} xl={6}>
-				<Grid container  spacing={1} alignItems="center">
-					<Grid item xs>
+      <Grid container spacing={2}>
+        <Grid item xs={12} lg={5} xl={6}>
+          <Grid container spacing={1} alignItems="center">
+            <Grid item xs>
+              <SearchBar
+                searchTerm={props.searchTerm}
+                setSearchTerm={props.setSearchTerm}
+                repoNames={props.tableRows.map((row: any) => row.name)}
+              />
+            </Grid>
+            <Grid item xs="auto">
+              <IconButton
+                sx={{ display: { xs: "initial", md: "none" } }}
+                aria-label="Sort and filter"
+                onClick={toggleFilter}
+              >
+                <FilterListIcon
+                  fontSize="medium"
+                  color={filterOpen ? "primary" : "inherit"}
+                />
+              </IconButton>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item xs={12} md={4} lg={2.33} xl={2} sx={filterSelectGridDisplay}>
+          {props.sortDropdown}
+        </Grid>
+        <Grid item xs={12} md={4} lg={2.33} xl={2} sx={filterSelectGridDisplay}>
+          {props.sortDirection}
+        </Grid>
+        <Grid item xs={12} md={4} lg={2.33} xl={2} sx={filterSelectGridDisplay}>
+          {props.rankSelection}
+        </Grid>
+      </Grid>
 
-						<SearchBar
-								searchTerm={props.searchTerm}
-								setSearchTerm={props.setSearchTerm}
-								repoNames={(props.tableRows.map((row: any) => row.name))}
-								/>
-					</Grid>
-					<Grid item xs="auto">
-							<IconButton
-								sx={{ display: { xs: 'initial', md: 'none' } }}
-								aria-label='Sort and filter'
-								onClick={toggleFilter}
-								>
-								<FilterListIcon
-									fontSize='medium'
-									color={filterOpen ? 'primary' : 'inherit'}
-									/>
-							</IconButton>
-						</Grid>
-					</Grid>
-				</Grid>
-				<Grid item xs={12} md={4} lg={2.33} xl={2} sx={filterSelectGridDisplay}>
-					{props.sortDropdown}
-				</Grid>
-				<Grid item xs={12} md={4} lg={2.33} xl={2} sx={filterSelectGridDisplay}>
-					{props.sortDirection}
-				</Grid>
-				<Grid item xs={12} md={4} lg={2.33} xl={2} sx={filterSelectGridDisplay}>
-					{props.rankSelection}
-				</Grid>
-			</Grid>
+      {props.filterSetting.mustHaveDependency != -1 ? (
+        <Grid item xs="auto" sx={{ paddingTop: "1rem" }}>
+          <Chip
+            variant="outlined"
+            sx={{
+              "& .MuiChip-label": {
+                fontFamily: "var(--primary-font-family)",
+				fontWeight: "var(--font-weight-semibold)",
+          		fontSize: "var(--font-size-large)",
+              },
+              color: "var(--colour-font)",
+            }}
+            label={
+              "Depends on: " +
+              props.JSObject.depMap.get(
+                props.filterSetting.mustHaveDependency as ID
+              )!.name
+            }
+            onDelete={deleteChip}
+          />
+        </Grid>
+      ) : (
+        <></>
+      )}
 
-			{
-				props.filterSetting.mustHaveDependency != -1 ?
-				<Grid item xs="auto" sx={{paddingTop: "1rem"}}>
-					<Chip variant="outlined" sx={{color: "var(--colour-font)"}} label={"Depends on: " + props.JSObject.depMap.get(props.filterSetting.mustHaveDependency as ID)!.name} onDelete={deleteChip} />
-				</Grid> : <></>
-			}
-
-			<GridTable rows={props.finalisedData} emptyRows={props.emptyRows} searchTerm={props.searchTerm} tableRows={props.tableRows}/>
-			{/* TODO: Delete this */}
-			{/* <div className={styles.tableStyle}>
+      <GridTable
+        rows={props.finalisedData}
+        emptyRows={props.emptyRows}
+        searchTerm={props.searchTerm}
+        tableRows={props.tableRows}
+      />
+      {/* TODO: Delete this */}
+      {/* <div className={styles.tableStyle}>
 				<CollapsibleTable tableRows={props.tableRows} setTableRows={props.setTableRows} searchAndFilteredData={searchAndFilteredData}></CollapsibleTable>
 			</div> */}
-		</Box>
-	);
+    </Box>
+  );
 }

--- a/components/ReposTableComponents/DependenciesContainer.tsx
+++ b/components/ReposTableComponents/DependenciesContainer.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import styles from "../../styles/DependenciesContainer.module.css";
 import sharedStyles from "../../styles/TreeView.module.css";
 import SearchBar from "./SearchBar";
-import { DependencyData } from "../../src/dataProcessing";
+import { DependencyData, ID } from "../../src/dataProcessing";
 import { Filter } from "../../src/sortingAndFiltering";
 import { ProcessedDependencyData } from "../../hooks/useProcessDependencyData";
 import { GridTable } from "../MobileComponents/GridTable";
 import FilterListIcon from '@mui/icons-material/FilterList';
-import { Box, Grid, IconButton } from "@mui/material";
+import { Box, Chip, Grid, IconButton } from "@mui/material";
 import {
 	PageLoaderCurrentData,
 	forceNewVersion,
@@ -16,6 +16,9 @@ import {
 	PageLoaderSetData,
 	PageLoaderSetLoading,
 } from "../PageLoader";
+
+import {topOfRepoBox} from "../Page"
+
 let refreshing = false;
 
 /* Container includes  Search, Filter, Dependencies Table */
@@ -30,6 +33,7 @@ export default function DependenciesContainer(props: {
 	emptyRows: boolean;
 	sortDirection: JSX.Element;
 	filterSetting: Filter;
+	setFilterSetting: React.Dispatch<React.SetStateAction<Filter>>;
 	targetOrganisation: string;
 	finalisedData: ProcessedDependencyData;
 }) {
@@ -71,6 +75,10 @@ export default function DependenciesContainer(props: {
 		setFilterOpen(!filterOpen);
 	};
 
+	const deleteChip = () => {
+		props.setFilterSetting({...props.filterSetting, mustHaveDependency: -1})
+	};
+
 	const filterSelectGridDisplay = {
 		display: {
 			xs: filterOpen ? "block" : "none",
@@ -79,7 +87,7 @@ export default function DependenciesContainer(props: {
 	};
 
 	return (
-		<Box className={styles.sectionContainer} sx={{
+		<Box ref={topOfRepoBox.data} className={styles.sectionContainer} sx={{
 			padding: {
 				xs: 2,
 				md: '2.5rem 3.125rem 3.75rem 3.125rem',
@@ -98,7 +106,6 @@ export default function DependenciesContainer(props: {
 								repoNames={(props.tableRows.map((row: any) => row.name))}
 								/>
 					</Grid>
-
 					<Grid item xs="auto">
 							<IconButton
 								sx={{ display: { xs: 'initial', md: 'none' } }}
@@ -123,6 +130,13 @@ export default function DependenciesContainer(props: {
 					{props.rankSelection}
 				</Grid>
 			</Grid>
+
+			{
+				props.filterSetting.mustHaveDependency != -1 ?
+				<Grid item xs="auto" sx={{paddingTop: "1rem"}}>
+					<Chip variant="outlined" sx={{color: "var(--colour-font)"}} label={"Depends on: " + props.JSObject.depMap.get(props.filterSetting.mustHaveDependency as ID)!.name} onDelete={deleteChip} />
+				</Grid> : <></>
+			}
 
 			<GridTable rows={props.finalisedData} emptyRows={props.emptyRows} searchTerm={props.searchTerm} tableRows={props.tableRows}/>
 			{/* TODO: Delete this */}

--- a/components/SummaryComponents/ReposSecondarySummaryTable.tsx
+++ b/components/SummaryComponents/ReposSecondarySummaryTable.tsx
@@ -14,6 +14,8 @@ import { compareSemVerDelta, SemVerDelta, semVerToDelta } from "../../src/semVer
 import { Filter } from "../../src/sortingAndFiltering";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 
+import {topOfRepoBox} from "../Page"
+
 // Customising the table styling using ThemeProvider
 let baseTheme = {
 					fontWeight: "var(--font-weight-semibold)",
@@ -115,7 +117,12 @@ function MostCommonSummaryTable(name: string, usageCounts: { name: string, id: n
 						usageCounts.map(i => {
 							return <div key={i.id + " containingDiv"}>
 								<ThemeProvider theme={innerRowTheme}>
-								<TableRow key={i.id} sx={{ display: "inline-block", width: "100%", ...(filterTerm.mustHaveDependency == i.id && { background: "var(--colour-table-selected)" }) }} onClick={() => setFilterTerm({ ...filterTerm, mustHaveDependency: filterTerm.mustHaveDependency == i.id ? -1 : i.id })}>
+								<TableRow key={i.id} sx={{ display: "inline-block", width: "100%", ...(filterTerm.mustHaveDependency == i.id && { background: "var(--colour-table-selected)" }) }} onClick={() => {
+									setFilterTerm({ ...filterTerm, mustHaveDependency: filterTerm.mustHaveDependency == i.id ? -1 : i.id })
+									// @ts-ignore
+									topOfRepoBox.data.current.scrollIntoView({ behavior: "smooth" });
+									// An ignore is used here as we don't know the exact type the above will be in this file.
+								}}>
 									<TableCell className={styles.tableCellStyle1}>
 										<div className={styles.textContainer}>
 											{i.name}


### PR DESCRIPTION
Adds a "chip" whenever a filter option is selected from the secondary summary table.
Additionally, the view is scrolled to the repo list, and the chip is able to be removed (clearing the filter).

This somewhat solves #216 